### PR TITLE
Fix documentation so that 'cargo test' now passes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,9 @@ impl HashTypes {
 ///
 /// # Example
 /// ```
-/// use rust-multihash:::{HashTypes, multihash};
+/// use rust_multihash::{HashTypes, multihash};
 ///
-/// let testphrase = b"Hello World"
+/// let testphrase = b"Hello World";
 /// let digest = multihash(HashTypes::SHA2512, testphrase.to_vec());
 /// ```
 pub fn multihash(wanthash: HashTypes, input: Vec<u8>) -> Result<Vec<u8>, String> {


### PR DESCRIPTION
The change to use an underscore instead of a dash is documented in issue 23533 of the rust-lang repo
